### PR TITLE
Run chez-cps benchmarks

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install generator dependencies
         run: |
           sudo apt -y update
-          sudo apt -y install jq cloc python3 git time llvm-18 clang gawk hyperfine
+          sudo apt -y install jq cloc python3 git time llvm-18 clang chezscheme gawk hyperfine
 
       - name: Generate data
         run: |

--- a/generate/backends.sh
+++ b/generate/backends.sh
@@ -3,7 +3,7 @@ set -e
 
 >&2 echo "$0"
 
-BACKENDS="llvm js"
+BACKENDS="llvm js chez-cps"
 
 merge() {
 	backend=$1

--- a/generate/benchmarks.sh
+++ b/generate/benchmarks.sh
@@ -22,7 +22,7 @@ done
 # now also measure execution time of backends based on benchmark configuration
 RUNS=5
 PRERUNS=2
-BACKENDS="llvm js"
+BACKENDS="llvm js chez-cps"
 
 benchmark() {
 	backend=$1

--- a/generate/out_loc.sh
+++ b/generate/out_loc.sh
@@ -15,4 +15,8 @@ cd ../effekt/out/
 	echo "{\"js\":"
 	cloc --by-file --json *.js | jq 'del(.header)'
 	echo "}"
+
+	echo "{\"chez-cps\":"
+	cloc --by-file --json *.ss | jq 'del(.header)'
+	echo "}"
 } | jq -s 'add'

--- a/generate/reference/effekt.sh
+++ b/generate/reference/effekt.sh
@@ -5,7 +5,7 @@ set -e
 
 cd ../effekt/
 
-BACKENDS="llvm js"
+BACKENDS="llvm js chez-cps"
 
 # Hyperfine can only write JSON to files
 tmpfile=$(mktemp /tmp/hyperfine_effekt.XXXXX)


### PR DESCRIPTION
Missing:

- UI inclusion
- `effekt/examples/benchmarks/config_chez-cps.txt` - should we just use the JS config for now? @phischu 