### PR TITLE
Use modified Z for outlier detection

### DIFF
--- a/alerts/backends.py
+++ b/alerts/backends.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import statistics
 import json
@@ -6,8 +6,9 @@ import sys
 import os
 
 N = 10
-Z_THRESHOLD = 3
+MODIFIED_Z_THRESHOLD = 10 # ~ 7 sigma
 DIR = "../data/backends/"
+EPSILON = sys.float_info.epsilon
 
 files = sorted(os.listdir(DIR))
 data = [o for f in files for o in json.load(open(f"{DIR}/{f}"))]
@@ -37,12 +38,20 @@ for backend in backends:
         if len(runs) < 5:
             continue
 
+        newest = merged[backend][file][-1]
+
         mean = statistics.mean(runs)
         sd = statistics.stdev(runs)
+        # uses Median Absolute Deviation to (try to) be robust to historical outliers.
+        med = statistics.median(runs)
+        mad = statistics.median([abs(x - med) for x in runs])
+        if mad == 0:
+            # all values are identical ~> any deviation is significant
+            mad = EPSILON
 
-        newest = merged[backend][file][-1]
-        z = (newest - mean) / sd
-        if abs(z) > Z_THRESHOLD:
+        mz = (newest - med) / mad
+
+        if abs(mz) > MODIFIED_Z_THRESHOLD:
             outliers.append(
                 {
                     "backend": backend,
@@ -50,20 +59,22 @@ for backend in backends:
                     "value": newest,
                     "mean": mean,
                     "sd": sd,
-                    "z": z,
+                    "median": med,
+                    "mad": mad,
+                    "mz": mz,
                 }
             )
 
 
-def emoji(z):
+def emoji(mz):
     SIGNIFICANT_MULT = 1.333
-    if z > 0:
-        if z > SIGNIFICANT_MULT * Z_THRESHOLD:
+    if mz > 0:
+        if mz > SIGNIFICANT_MULT * MODIFIED_Z_THRESHOLD:
             return "⏫"
         else:
             return "🔼"
     else:
-        if z < -SIGNIFICANT_MULT * Z_THRESHOLD:
+        if mz < -SIGNIFICANT_MULT * MODIFIED_Z_THRESHOLD:
             return "⏬"
         else:
             return "🔽"
@@ -71,11 +82,11 @@ def emoji(z):
 
 if outliers:
     print("# Backend outliers detected!\n")
-    print(f"Configuration: `N={N}`, significant if `z-score > {Z_THRESHOLD}`\n")
+    print(f"Configuration: `N={N}`, significant if `modified z-score > {MODIFIED_Z_THRESHOLD:.2f}`\n")
     print(
         "\n".join(
             [
-                f"- {emoji(outlier['z'])} in backend: {outlier['backend']}, file: `{outlier['file']}`, time: {outlier['value'] / 1e9:.3f}s (μ={outlier['mean']/1e9:.3f}s, σ={outlier['sd']/1e9:.3f}s, z={outlier['z']:.3f})"
+                f"- {emoji(outlier['mz'])} in backend: {outlier['backend']}, file: `{outlier['file']}`, time: {outlier['value'] / 1e9:.3f}s (μ={outlier['mean']/1e9:.3f}s, σ={outlier['sd']/1e9:.3f}s, median={outlier['median']/1e9:.3f}s, MAD={outlier['mad']/1e9:.4f}s, mz={outlier['mz']:.2f})"
                 for outlier in outliers
             ]
         )


### PR DESCRIPTION
I read through Chapter 3 of `Iglewicz, B., & Hoaglin, D. C. (1993). Volume 16: how to detect and handle outliers. Quality Press.` and tried to implement the modified Z they have for outliers as that's what hyperfine uses.
I explicitly avoided looking at hyperfine's source, only searching for what technique they use, then implementing it myself after reading the chapter. This should be resistant to historical outliers, which is great for us :)

If ran, it currently flags only networked numbers (see below), but not stuff like sum range with `1.087s (μ=1.038s, σ=0.010s, z=4.884)` which is likely bogus.

```
# Backend outliers detected!

Configuration: `N=10`, significant if `modified z-score > 10.00`

- ⏫ in backend: js, file: `input_output/networked_numbers`, time: 1.635s (μ=1.490s, σ=0.012s, median=1.490s, MAD=0.0104s, mz=13.96)
```